### PR TITLE
Change footnote size

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -6,7 +6,7 @@ $mobile-logo-height: 60px;
 $desktop-logo-height: 80px;
 $desktop-homepage-width: 1200px;
 $desktop-column-width: 780px;
-$footnote-column-width: 220px;
+$footnote-column-width: 200px;
 $compost-green: #336633;
 $link-color: $compost-green;
 $title-sans-serif: 'Open Sans', sans-serif;
@@ -427,7 +427,7 @@ main {
 
     .footnotes-container {
       position: absolute;
-      font-size: 16px;
+      font-size: 0.7em;
       // font-weight: 300;
       top: 0px;
       left: $desktop-column-width;

--- a/content/pieces/the-ocean-swallowed-a-cable/index.md
+++ b/content/pieces/the-ocean-swallowed-a-cable/index.md
@@ -138,6 +138,6 @@ Every time the men lifted her up now she still winked at the sun, but wished upo
 
 ## Notes
 
-Ingrid Burrington has called the Internet “the largest terraforming project” in existence. If you are even mildly interested in this piece, you may be deeply interested in Burrington’s work (http://lifewinning.com/).
+Ingrid Burrington has called the Internet “the largest terraforming project” in existence. If you are even mildly interested in this piece, you may be deeply interested in Burrington’s work ([http://lifewinning.com/](http://lifewinning.com/)).
 
 Gratitude to Giovanna, Elina, Abhishek, Nick Zurku (co-founder of the Pittsburgh Internet Exchange), the Bridge #science channel, Caro, Austin, Strange Friend Brian, Aurelia, Smol Dyke, and all the COMPOST crew. Writing is terrifying and lonely, but you all make it feel less so.


### PR DESCRIPTION
This makes the content pop more (the footnote font size was too close to main text) by matching the font size to footer text instead of 16px. It shrinks the column a bit bc on my mac screen I was getting a horizontal scroll bar which was super weird.

<img width="1260" alt="Screen Shot 2021-02-27 at 10 19 04 PM" src="https://user-images.githubusercontent.com/2261308/109406821-1615cb80-794a-11eb-9de5-10b16a58b873.png">
