### PR TITLE
Point footer protocol hop links to corresponding dweb page

### DIFF
--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -12,10 +12,10 @@
     <p>COMPOST is published to the web and <a href="https://getdweb.net" target="_blank">DWeb</a> using the <a
         href="https://github.com/hyphacoop/api.distributed.press" target="_blank">Distributed Press API</a>.</p>
     <p>Read it on:</p>
-    <div><a href="https://one.compost.digital" target="_blank">https://one.compost.digital</a></div>
-    <div><a href="https://ipfs.distributed.press/ipns/one.compost.digital/"
-        target="_blank">ipns://one.compost.digital</a></div>
-    <div><a href="https://hyper.distributed.press/one.compost.digital/" target="_blank">hyper://one.compost.digital</a>
+    <div><a href="https://one.compost.digital{{ .URL }}" target="_blank">https://one.compost.digital »</a></div>
+    <div><a href="https://ipfs.distributed.press/ipns/one.compost.digital{{ .URL }}"
+        target="_blank">ipns://one.compost.digital »</a></div>
+    <div><a href="https://hyper.distributed.press/one.compost.digital{{ .URL }}" target="_blank">hyper://one.compost.digital »</a>
     </div>
     <p>Website content is licensed under a <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International license</a>.</p>
   </div>


### PR DESCRIPTION
Re-ticketed from https://chat.tomesh.net/#/room/#hyphacoop-open:tomesh.net/$1615253829351yBFoQ:tomesh.net

Added subtle little double-angle arrows to hint that the link is a little different than normal (not spelling out who page in text though). Maybe another hint/char is better (or none).

<img width="416" alt="Screen Shot 2021-03-09 at 12 01 05 AM" src="https://user-images.githubusercontent.com/305339/110420991-90d99780-806a-11eb-98b9-10054d84d7a2.png">

Close at will if you don't like it. (I did this in the footer of the Hypha website as well, but happy to change that to whatever pattern you decide here :) )